### PR TITLE
fix March 2021 issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,5 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-install:
-  - python setup.py install
 script:
-  - python setup.py test
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+install:
+  - pip install -r requirements.txt
 script:
   - pytest

--- a/photosynq_py/buildframe.py
+++ b/photosynq_py/buildframe.py
@@ -274,7 +274,8 @@ def build_project_dataframe(project_info, project_data):
                         msmnt_dict[param] = value
                         
             # append a row to the dataframe for this protocolID
-            spreadsheet[protocolID].iloc[i,:] = Series(msmnt_dict)
+            for column,value in msmnt_dict.items():
+                spreadsheet[protocolID].loc[i,column] = value
             num_result_rows_by_protocol[protocolID] = i+1
 
     for protocol in list(spreadsheet.keys()):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pandas

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 setup(
     name = "photosynq_py",
-    version = "0.28",
+    version = "0.29",
     packages = ['photosynq_py'],
     test_suite = 'tests',
 

--- a/tests/buildframe_test.py
+++ b/tests/buildframe_test.py
@@ -5,7 +5,7 @@ Test file corresponding with photosynq_py.buildframe
 from numbers import Number
 from datetime import datetime
 from unittest import TestCase
-from pandas import DataFrame
+import pandas as pd
 import json
 import numpy as np
 import photosynq_py as ps
@@ -29,8 +29,8 @@ class BuildframeTest(TestCase):
             RESOURCE_FOLDER + "1224_info_from_api")["project"]
         self.test_data = self.load_json(
             RESOURCE_FOLDER + "1224_data_from_api")["data"]
-        self.resource_dataframe = DataFrame.from_csv(
-            RESOURCE_FOLDER + "1224_csv_from_website.csv")
+        self.resource_dataframe = pd.read_csv(
+            RESOURCE_FOLDER + "1224_csv_from_website.csv", index_col=0)
 
     def test_build_project_dataframe(self):
         """


### PR DESCRIPTION
fixed an error when building a dataframe for certain projects, for example: 

get_project_dataframe(10510, raw_traces=True)

previously this would cause an error "ValueError: could not broadcast input array from shape..."